### PR TITLE
 Update admin config reference. Allow token generator to access pki admin data.

### DIFF
--- a/deploy/helm/kubefarm/templates/token-generator-job.yaml
+++ b/deploy/helm/kubefarm/templates/token-generator-job.yaml
@@ -42,15 +42,20 @@ spec:
           readOnly: true
         - mountPath: /scripts
           name: scripts
+        - mountPath: /pki/admin-client
+          name: pki-admin-client
       volumes:
       - name: kubeconfig
-        secret:
+        configMap:
           defaultMode: 420
-          secretName: {{ template "kubernetes.fullname" . }}-admin-conf
+          name: {{ template "kubernetes.fullname" . }}-admin-conf
       - name: scripts
         configMap:
           name: {{ $fullName }}-scripts
           defaultMode: 0777
+      - secret:
+          secretName: "cluster-kubernetes-pki-admin-client"
+        name: pki-admin-client
       restartPolicy: OnFailure
       serviceAccountName: {{ $fullName }}-token-generator
 {{- end }}


### PR DESCRIPTION
- Cron/Job pod creation fails otherwise. 

```
C:\Users\shaba>kubectl get configmap
NAME                                         DATA   AGE
cluster-kubernetes-admin-conf                1      90m
```
admin config is generated as a configmap.

- Cron/Job run fails otherwise. 
Bash script references access to ` /pki/admin-client` and complains if it doesn't exist. 